### PR TITLE
add blockLag to metrics

### DIFF
--- a/collector/rpc_metrics.go
+++ b/collector/rpc_metrics.go
@@ -66,6 +66,13 @@ func NewNodeRpcMetrics(
 			nil,
 			nil,
 		),
+
+		blockNumberDesc: prometheus.NewDesc(
+			"block_number",
+			"The head of the NEAR chain",
+			nil,
+			nil,
+		),
 		blockLagDesc: prometheus.NewDesc(
 			"near_block_lag",
 			"The number of blocks behind rpc endpoint block head.",

--- a/collector/rpc_metrics.go
+++ b/collector/rpc_metrics.go
@@ -68,7 +68,7 @@ func NewNodeRpcMetrics(
 		),
 
 		blockNumberDesc: prometheus.NewDesc(
-			"block_number",
+			"near_block_number",
 			"The head of the NEAR chain",
 			nil,
 			nil,

--- a/main.go
+++ b/main.go
@@ -51,7 +51,7 @@ func main() {
 
 	registry := prometheus.NewPedanticRegistry()
 	registry.MustRegister(
-		collector.NewNodeRpcMetrics(client, *accountId),
+		collector.NewNodeRpcMetrics(client, devClient, *accountId),
 		collector.NewDevNodeRpcMetrics(devClient),
 	)
 


### PR DESCRIPTION
# What
Add a metric for measuring `block lag`. Block lag is the number of blocks behind the external rpc's block height the internal node is.

# Why
This comparison was not previously available.