### PR TITLE
reduce load on internal node

### DIFF
--- a/collector/rpc_metrics.go
+++ b/collector/rpc_metrics.go
@@ -163,7 +163,7 @@ func (collector *NodeRpcMetrics) Collect(ch chan<- prometheus.Metric) {
 	versionBuildInt := HashString(sr.Status.Version.Build)
 	ch <- prometheus.MustNewConstMetric(collector.versionBuildDesc, prometheus.GaugeValue, float64(versionBuildInt), sr.Status.Version.Version, sr.Status.Version.Build)
 
-	r, err := collector.internalClient.Get("validators", []uint64{intBlockHeight})
+	r, err := collector.externalClient.Get("validators", []uint64{intBlockHeight})
 	if err != nil {
 		ch <- prometheus.NewInvalidMetric(collector.epochBlockBroducedDesc, err)
 		ch <- prometheus.NewInvalidMetric(collector.epochBlockExpectedDesc, err)


### PR DESCRIPTION
Calling the “validators” rpc endpoint on a node, especially when out of sync, is super expensive for a near node. This PR changes the  "validators" call to request from the externalNode.